### PR TITLE
added filter by status

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -243,13 +243,11 @@ export class DashboardComponent implements OnInit {
    */
   async filter(filter: { status: string[], workrole: string[], task: string[], audience: string[]}) {
     this.loading = true;
-    
     // filter competencies by status
     this.search.statuses = filter.status;
     await this.getCompetencies(this.search);
     await this.loadCompetencies();
     this.filterApplied = true;
-
     this.loading = false;
   }
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -28,7 +28,8 @@ export class DashboardComponent implements OnInit {
     competencies: [],
     limit: 12,
     page: 1,
-    total: 0
+    total: 0,
+    statuses: []
   };
   urlParams: Record<string, string> = {};
   // Pagination default val
@@ -80,7 +81,8 @@ export class DashboardComponent implements OnInit {
       competencies: [],
       limit: 12,
       page: 1,
-      total: 0
+      total: 0,
+      statuses: []
     };
     if (this.urlParams) {
       this.makeQuery(this.urlParams);
@@ -107,7 +109,7 @@ export class DashboardComponent implements OnInit {
           limit: q ? q.limit : this.search.limit,
           page:  q ? q.page : this.search.page,
           author: this.authService.user?._id,
-          status: [
+          status: (q && q.statuses.length > 0) ? q.statuses : [
             `${Lifecycles.DRAFT}`,
             `${Lifecycles.REJECTED}`,
             `${Lifecycles.SUBMITTED}`,
@@ -120,7 +122,8 @@ export class DashboardComponent implements OnInit {
         competencies: [],
         limit: 12,
         page: 1,
-        total: 0
+        total: 0,
+        statuses: []
       };
     }
   }
@@ -239,7 +242,15 @@ export class DashboardComponent implements OnInit {
    * @param filter object containing arrays of selected filters
    */
   async filter(filter: { status: string[], workrole: string[], task: string[], audience: string[]}) {
-    console.log('FILTER BASED SEARCHING NOT IMPLEMENTED YET.', filter);
+    this.loading = true;
+    
+    // filter competencies by status
+    this.search.statuses = filter.status;
+    await this.getCompetencies(this.search);
+    await this.loadCompetencies();
+    this.filterApplied = true;
+
+    this.loading = false;
   }
 
   /**

--- a/src/entity/Search.ts
+++ b/src/entity/Search.ts
@@ -5,6 +5,7 @@ export interface Search {
   limit: number
   page: number
   total: number
+  statuses: string[]
 }
 
 export function CompetencyCardSearch(id: string) {


### PR DESCRIPTION
Added filter competencies by statuses:
* If no status filter is given:
    + it would load competencies with `draft`, `rejected`, `submitted`, and `published` statuses
* else:
    + it would load competencies with the given statuses

Note:
The styling of the dropdown does not indicate which status is being clicked or selected.


https://user-images.githubusercontent.com/72763770/234670360-66ccf9d0-e9b4-4107-a793-5409608e9aea.mov

